### PR TITLE
fix: net/url in newer versions of Go (>1.9.4) reject with "invalid userinfo" when there are special characters in the connection string

### DIFF
--- a/src/db-migrate-function/index.ts
+++ b/src/db-migrate-function/index.ts
@@ -140,11 +140,14 @@ const buildConnectionString = (
 ): string => {
   const { username, password, host, port, engine } = databaseSecret;
 
+  const encodedPassword = encodeURIComponent(password);
+  const encodedUsername = encodeURIComponent(username);
+
   switch (engine) {
     case 'mysql':
-      return `mysql://${username}:${password}@tcp(${host}:${port})/${dbName}`;
+      return `mysql://${encodedUsername}:${encodedPassword}@tcp(${host}:${port})/${dbName}`;
     case 'postgres':
-      return `postgres://${username}:${password}@${host}:${port}/${dbName}`;
+      return `postgres://${encodedUsername}:${encodedPassword}@${host}:${port}/${dbName}`;
     default:
       throw new Error(
         `Unsupported (or not yet implemented) database engine for migrate target: ${databaseSecret.engine}`,


### PR DESCRIPTION
Per [this patch to go](https://github.com/golang/go/commit/ba1018b4549f3edc257221cc8e49221255e03290), when we have an auto-generated password that contains special characters, net/url throws an invalid userinfo error. 

This PR encodes the username and password in the connection string. 

It deliberately does not bother with the host, port or dbName as all three already have limited character sets.